### PR TITLE
add Solana balance check command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ google-auth-httplib2==0.2.0
 httplib2==0.22.0
 soupsieve==2.6
 urllib3==2.3.0
+solana==0.36.6
+solders>=0.23.0,<0.27.0
+base58>=2.1.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `/balance` command, enabling users to check Solana token balances by providing a wallet address or SNS domain. The command returns token details including the name, symbol, and balance.

- **Chores**
  - Updated dependencies to enhance integration with Solana functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->